### PR TITLE
ci: align release bot and dependency policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         id: release-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.GD_RELEASE_BOT_CLIENT_ID }}
+          app-id: ${{ vars.GD_RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.GD_RELEASE_BOT_PRIVATE_KEY }}
           permission-contents: write
           permission-issues: write

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.1",
   "description": "Kirby CMS plugin for visualising hidden characters in the Panel",
   "license": "MIT",
-  "packageManager": "pnpm@11.11.0",
+  "packageManager": "pnpm@11.22.0",
   "scripts": {
     "setup": "pnpm install --frozen-lockfile && pnpm exec playwright install chromium",
     "update:dev": "pnpm update --dev --prod",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
   - .
 
+minimumReleaseAge: 1440
+minimumReleaseAgeStrict: true
+
 nodeLinker: isolated
 
 allowBuilds:


### PR DESCRIPTION
## Summary

- use the supported GitHub App ID input for release-token creation
- enforce the shared one-day pnpm release-age policy in strict mode

## Verification

- composer and Node verification passed
- 10 Playwright browser tests passed
- actionlint passed

This implements the dependency policy independently from contributor PR #27 so the setting remains consistent across the maintained pnpm plugin group.