### PR TITLE
ci: use release bot client ID

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+paths:
+  .github/workflows/ci.yml:
+    ignore:
+      # actionlint 1.7.12 bundles pre-client-id metadata for this v3 action.
+      - 'missing input "app-id" which is required by action "actions/create-github-app-token@v3"'
+      - 'input "client-id" is not defined in action "actions/create-github-app-token@v3"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         id: release-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.GD_RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.GD_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.GD_RELEASE_BOT_PRIVATE_KEY }}
           permission-contents: write
           permission-issues: write


### PR DESCRIPTION
## Summary
- use the current create-github-app-token client-id input
- remove the hosted deprecation warning
- narrowly ignore actionlint 1.7.12's stale v3 input metadata

## Verification
- actionlint .github/workflows/*.yml
- git diff --check